### PR TITLE
Feature/fancy updates

### DIFF
--- a/ImportExportIotDevices/env.vars.sh
+++ b/ImportExportIotDevices/env.vars.sh
@@ -13,7 +13,7 @@ echo
 
 export SOURCE_IOTHUB_CONN_STRING_CSHARP=$(az iot hub connection-string show --hub-name iot-playground-devices-hub --resource-group iot-playground-rsg -o tsv)
 export DEST_IOTHUB_CONN_STRING_CSHARP=$(az iot hub connection-string show --hub-name $HUB --resource-group $RSG -o tsv)
-export STORAGE_CONN_STRING_CSHARP=$(az storage account show-connection-string --name iotstg$SUFIX --resource-group $RSG -o tsv)
+export STORAGE_CONN_STRING_CSHARP=$(az storage account show-connection-string --name iotstg$SUFFIX --resource-group $RSG -o tsv)
 
 echo "SOURCE_IOTHUB_CONN_STRING_CSHARP=$SOURCE_IOTHUB_CONN_STRING_CSHARP"
 echo "DEST_IOTHUB_CONN_STRING_CSHARP=$DEST_IOTHUB_CONN_STRING_CSHARP"

--- a/ImportExportIotDevices/env.vars.sh
+++ b/ImportExportIotDevices/env.vars.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-## ENSURE YOU SET THE CORRECT RSG and HUB
+## ENSURE YOU SET THE CORRECT RSG and HUB in ../variables.sh
 ## MAKE THIS SCRIPT AN EXECUTABLE SCRIPT BY RUNNING: chmod +x env.vars.sh
 ## RUN THE SCRIPT BY RUNNING: . env.vars.sh or source env.vars.sh
 
-export SUFIX=bcdr
-export RSG=iot-$SUFIX
-export HUB=iot-$SUFIX-hub
+source ${BASH_SOURCE%/*}/../variables.sh
 
 echo ">>>>>>>>>>>>>>>>>>>"
 echo "Setting environment variables for export - import device identities"

--- a/IotDeviceSimulator/env.vars.sh
+++ b/IotDeviceSimulator/env.vars.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-## ENSURE YOU SET THE CORRECT RSG and HUB
+## ENSURE YOU SET THE CORRECT RSG and HUB in ../variables.sh
 ## MAKE THIS SCRIPT AN EXECUTABLE SCRIPT BY RUNNING: chmod +x env.vars.sh
 ## RUN THE SCRIPT BY RUNNING: . env.vars.sh or source env.vars.sh
 
-export SUFIX=bcdr
-export RSG=iot-$SUFIX
-export HUB=iot-$SUFIX-hub
+source ${BASH_SOURCE%/*}/../variables.sh
 
 echo ">>>>>>>>>>>>>>>>>>>"
 echo "Setting environment variables for IoTDeviceSimulator"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Keep in mind to consider the devices as part of the important pieces for BC/DR
 ## Environment Setup
 1. Scripts are designed to run in bash and assume you are logged in to run az cli commands (az login).
 2. Execute the `setup.env.sh` script to create the whole environment
-3. Build & Deploy IoT Device Simulator by running the `build-deploy.sh` script. You will need to introduce the vm password to copy the binaries.
+3. Build & Deploy IoT Device Simulator by running the `build-deploy.sh` script. You will need [.net SDK installed](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu).
 4. Ensure the Internet traffic is blocked from the VM by running the device simulator: `~/iot-device-simulator$ ./run-simulator.sh`, it will not be able to connect.
 5. Close IoT HUB public access and configure IoT Hub Private Endpoints within the WE VNET.
     - Allow access to your IP for managing purposes.
@@ -34,7 +34,7 @@ Keep in mind to consider the devices as part of the important pieces for BC/DR
         - You can verify the hub is not receiving traffic by executing `az iot hub monitor-events --output table -d edge101 -n iot-bcdr-hub -g iot-bcdr`
         - **WARN** - TO BE INVESTIGATED-: THIS POINT IS NOT TRUE, NOT SURE WHY, I EXPECT THE MODULE CAN CONTINUE SENDING TO THE EDGE HUB AND THE EDGE HUB TO STORE THE MESSAGES WHILE NOT CONNECTIVITY
         - **Anyway** the module will reconnect after the failover (edgeAgent take care of it). 
-8. OPTIONAL: Verify the Temperature Sensor Module and IoT Simulated Device are sending data properly and the IoT Hub is receiving it (from your computer you can run `az iot hub monitor-events --output table -d edge101 -n iot-bcdr-hub -g iot-bcdr` ` az iot hub monitor-events --output table -d thermostat1 -n iot-bcdr-hub -g iot-bcdr`)
+8. OPTIONAL: Verify the Temperature Sensor Module and IoT Simulated Device are sending data properly and the IoT Hub is receiving it (from your computer you can run `az iot hub monitor-events --output table -d edge101 -n iot-bcdr-hub -g iot-bcdr` `az iot hub monitor-events --output table -d thermostat1 -n iot-bcdr-hub -g iot-bcdr`)
 
 ## TESTS
 1. Fail Over with only one PE attached to WE region
@@ -96,5 +96,4 @@ Error. Description = {"Message":"{\"errorCode\":401002,\"trackingId\":\"5a2bc7c4
 
 ## Remarks
 Be mindful this content is "under development" & "quick and dirty". 
-TODO: Generate a VM pass dynamically. Now is defined in the script. Not an issue as this are transient environments.
 WARN: The shell scripts use the environment variable export `SUFIX=bcdr` to create the resources. If you change it in one of the scripts, change it in all (`setup.env.sh build-deploy.sh and ./IotDeviceSimulator/env.vars.sh`)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # iothub-bc-dr
+
 Business Continuity and Disaster Recover for IoT Hub
 
-## Scenarios:
+## Scenarios
+
 - Business Continuity:
   - IoT Hub needs to Fail Over, ensure the connectivity is maintained using the primary region PE.
-  - Network disruption (I imagine a possible issue like Express Route failure / Networking outage in the primary region so they need to Fail Over the IoT Hub + configure dns resolution for the PE in the secondary region.
+  - Network disruption (I imagine a possible issue like Express Route failure / Networking outage in the primary region) so they need to Fail Over the IoT Hub + configure dns resolution for the PE in the secondary region.
 
 - Disaster Recovery:
   - Cloning an IoT Hub
   - Using DPS
 
+Keep in mind to consider the devices as part of the important pieces for BC/DR:
 
-Keep in mind to consider the devices as part of the important pieces for BC/DR
 - React and Control Connectivity Events
 - Retries & Considerations
 
 ## Environment Setup
+
 1. Scripts are designed to run in bash and assume you are logged in to run az cli commands (az login).
 2. Execute the `setup.env.sh` script to create the whole environment
 3. Build & Deploy IoT Device Simulator by running the `build-deploy.sh` script. You will need [.net SDK installed](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu).
@@ -27,9 +30,9 @@ Keep in mind to consider the devices as part of the important pieces for BC/DR
 6. Execute the iot-device-simulator by running the `~/iot-device-simulator$ ./run-simulator.sh` now it should work thru the PE
 7. Configure the IoT Edge Temperature Sensor Module for the edge101 device using the ACR deployed with the environment
     - Enable the Private Endpoint to the ACR
-    - Ensure the Pivate DNS is linked to the VM VNET/SBNET to enable the resolution
-    - Configure the TemperatureSensorModule pointing to the image in the environemnt ACR, for example `iotacrbcdr.azurecr.io/azureiotedge-simulated-temperature-sensor:latest`
-    - You can add a "MessageCount" environment variable with -1 as value (no stop sending) or an ammount of messages to be sent high to allow the proper testing (i.e. 5000)
+    - Ensure the Private DNS is linked to the VM VNET/SBNET to enable the resolution
+    - Configure the TemperatureSensorModule pointing to the image in the environment ACR, for example `iotacrbcdr.azurecr.io/azureiotedge-simulated-temperature-sensor:latest`
+    - You can add a "MessageCount" environment variable with -1 as value (no stop sending) or an amount of messages to be sent high to allow the proper testing (i.e. 5000)
     - Verify the Temperature Sensor is able to send lost: `sudo iotedge logs SimulatedTemperatureSensor -f`.
         - You can verify the hub is not receiving traffic by executing `az iot hub monitor-events --output table -d edge101 -n iot-bcdr-hub -g iot-bcdr`
         - **WARN** - TO BE INVESTIGATED-: THIS POINT IS NOT TRUE, NOT SURE WHY, I EXPECT THE MODULE CAN CONTINUE SENDING TO THE EDGE HUB AND THE EDGE HUB TO STORE THE MESSAGES WHILE NOT CONNECTIVITY
@@ -37,14 +40,15 @@ Keep in mind to consider the devices as part of the important pieces for BC/DR
 8. OPTIONAL: Verify the Temperature Sensor Module and IoT Simulated Device are sending data properly and the IoT Hub is receiving it (from your computer you can run `az iot hub monitor-events --output table -d edge101 -n iot-bcdr-hub -g iot-bcdr` `az iot hub monitor-events --output table -d thermostat1 -n iot-bcdr-hub -g iot-bcdr`)
 
 ## TESTS
+
 1. Fail Over with only one PE attached to WE region
-    - Fail Over the IoT Hub and Check that the clients can continue sending data after a period of transient failure. 
-    - The IotDeviceSimulator, which is also suscribed to the EventHubsCompatible endpoint will need an updated PE configuration to continue working. The IoTDeviceSimulator automatically resolves the EventHubs compatible endpoint connection string thru the class `IoTHubConnection`.
+    - Fail Over the IoT Hub and Check that the clients can continue sending data after a period of transient failure.
+    - The IotDeviceSimulator, which is also subscribed to the EventHubsCompatible endpoint will need an updated PE configuration to continue working. The IoTDeviceSimulator automatically resolves the EventHubs compatible endpoint connection string thru the class `IoTHubConnection`.
     - After the Fail Over, the EventHubs compatible endpoint is changed. If a client is using this compatible endpoint thru PE (which is our case), then it needs to be reconfigured to point to the new EH Compatible Endpoint, this will require to **RE-CREATE** the PE (remove and recreate).
         - **OPPORTUNITY**: Fail over doc does not mention anything regarding private link / private endpoint -> this would be an interesting topic if there are customer that are using the EH compatible endpoint thru a PE. The scenario of having devices connected to the compatible endpoint is not so common.
     - Time tracking of a FailOver with a couple of devices (few minutes after requesting the Fail Over):
         - 14:03 -> Simulated Device stops sending and stop receiving, errors appear (retry in place). Edge TempSensor also stop sending
-        - 14:11 -> Simulated Device sends againg. Recive is broken (as per the EH Endpoint change). Edge takes a bit more due to the edgeAgent retries to re-start the module. 
+        - 14:11 -> Simulated Device sends again. Receive is broken (as per the EH Endpoint change). Edge takes a bit more due to the edgeAgent retries to re-start the module.
         - 14:13 -> Remove PE from the IoT Hub, remove Nic + Private Link resources.
         - 14:16 -> Recreate PE
         - 14:18 -> Simulated Device Send and Receive working. Edge device too.
@@ -55,13 +59,14 @@ Keep in mind to consider the devices as part of the important pieces for BC/DR
      - Remove the WE PE when possible
      - Create the NE PE when possible
      - Remove the Private DNS records from the VM VNET/SNET
-     - Attach the Private DNS records for the NE PE to the VM VNET/SNET 
+     - Attach the Private DNS records for the NE PE to the VM VNET/SNET
 
-  
 ## Disaster Recovery Notes
+
 Code in ImportExportIotDevices is a sample. It has been fixed to export the device identities WITH authorization settings as explained here:  
 Pay special attention to the fact that to export the identities with authentication you need to explicit specify it:
-```
+
+```C#
  var exportJob = JobProperties.CreateForExportJob(
                     _containerUri,
                     excludeKeysInExport: false,
@@ -72,32 +77,37 @@ Pay special attention to the fact that to export the identities with authenticat
                 await WaitForJobAsync(registryManager, exportJob);
 ```
 
-At the same time, be conscious of storing this information which contain SECRETS. 
+At the same time, be conscious of storing this information which contain SECRETS.
 
-### Execute the tool from dotnet run:
+### Execute the tool from dotnet run
 
 Only Export
+
 ``` az cli
 >[..] iothub-bc-dr/ImportExportIotDevices$ . env.vars.sh
 >[..] iothub-bc-dr/ImportExportIotDevices$ dotnet run --ExportDevices=true --IncludeConfigurations=true
 ```
 
 Export & Import
+
 ``` az cli
 >[..] iothub-bc-dr/ImportExportIotDevices$ . env.vars.sh
 >[..] iothub-bc-dr/ImportExportIotDevices$ dotnet run --CopyDevices=true --IncludeConfigurations=true
 ```
 
-### Known Issue
+### Known Issues
+
 If you get an 401002 error trying to import the devices from other hub, be sure your IP is whitelisted in the the Network firewall of the destination IoT Hub. An error like follows:
-```
+
+```bash
 Error. Description = {"Message":"{\"errorCode\":401002,\"trackingId\":\"5a2bc7c4750f42f5aabefc0de1cd06cc-G:0-TimeStamp:02/23/2023 17:47:52\",\"message\":\"Unauthorized\",\"timestampUtc\":\"2023-02-23T17:47:52.4627397Z\"}","ExceptionMessage":""}
 ```
 
 ## Remarks
-Be mindful this content is "under development" & "quick and dirty". 
-WARN: The shell scripts use the environment variable export `SUFIX=bcdr` to create the resources. This variable is defined in the `variables.sh` file and is referenced by all other scripts (`setup.env.sh`, `build-deploy.sh`, `./IotDeviceSimulator/env.vars.sh` and `./ImportExportIotDevices/env.vars.sh`). If you want to change the sufix with a random string use:
+
+Be mindful this content is "under development" & "quick and dirty".
+WARN: The shell scripts use the environment variable export `SUFFIX=bcdr` to create the resources. This variable is defined in the `variables.sh` file and is referenced by all other scripts (`setup.env.sh`, `build-deploy.sh`, `./IotDeviceSimulator/env.vars.sh` and `./ImportExportIotDevices/env.vars.sh`). If you want to change the SUFFIX with a random string use:
 
 ```bash
-find . -type f -name '*.sh' -exec sed -i -e "s/export SUFIX=[a-zA-Z0-9]*/export SUFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)dr/g" {} \;
+find . -type f -name '*.sh' -exec sed -i -e "s/export SUFFIX=[a-zA-Z0-9]*/export SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)dr/g" {} \;
 ```

--- a/README.md
+++ b/README.md
@@ -96,4 +96,8 @@ Error. Description = {"Message":"{\"errorCode\":401002,\"trackingId\":\"5a2bc7c4
 
 ## Remarks
 Be mindful this content is "under development" & "quick and dirty". 
-WARN: The shell scripts use the environment variable export `SUFIX=bcdr` to create the resources. If you change it in one of the scripts, change it in all (`setup.env.sh build-deploy.sh and ./IotDeviceSimulator/env.vars.sh`)
+WARN: The shell scripts use the environment variable export `SUFIX=bcdr` to create the resources. This variable is defined in the `variables.sh` file and is referenced by all other scripts (`setup.env.sh`, `build-deploy.sh`, `./IotDeviceSimulator/env.vars.sh` and `./ImportExportIotDevices/env.vars.sh`). If you want to change the sufix with a random string use:
+
+```bash
+find . -type f -name '*.sh' -exec sed -i -e "s/export SUFIX=[a-zA-Z0-9]*/export SUFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)dr/g" {} \;
+```

--- a/build-deploy.sh
+++ b/build-deploy.sh
@@ -8,8 +8,8 @@
 export SUFIX=bcdr
 export RSG=iot-$SUFIX
 export HUB=iot-$SUFIX-hub
-export VM_NAME='edgevm-'$SUFIX
-export HOST=$VM_NAME.westeurope.cloudapp.azure.com
+export VM_DNS_PREFIX='edgevm-'$SUFIX
+export SSH_KEY_NAME=iot_vm_rsa
 
 source ./IotDeviceSimulator/env.vars.sh
 
@@ -17,8 +17,8 @@ echo "Cleaning up simulator output folder."
 rm -rf ./IotDeviceSimulator/output
 
 echo "Cleaning up simulator folder on edge device."
-VM_NAME=$(az vm list -g $RSG --query "[].name" -o tsv)
-az vm run-command invoke -g $RSG  -n $VM_NAME --command-id RunShellScript --scripts "rm -rf /home/azureUser/iot-device-simulator && mkdir /home/azureUser/iot-device-simulator && chown azureUser /home/azureUser/iot-device-simulator"
+VM_NAME=$(az vm list -g $RSG -d --query "[?starts_with(fqdns,'$VM_DNS_PREFIX')].name" -o tsv)
+az vm run-command invoke -g $RSG -n $VM_NAME --command-id RunShellScript --scripts "rm -rf /home/azureUser/iot-device-simulator && mkdir /home/azureUser/iot-device-simulator && chown azureUser /home/azureUser/iot-device-simulator"
 
 echo "Publish content."
 dotnet publish ./IotDeviceSimulator/iot-device-simulator.csproj -c release -r linux-x64 --self-contained true --output ./IotDeviceSimulator/output
@@ -28,8 +28,9 @@ sed -i 's/##REPLACE_DEVICE_CONNSTR##/'$DEVICE_CONNSTR'/g' ./IotDeviceSimulator/o
 
 chmod +x ./IotDeviceSimulator/output/iot-device-simulator
 
-echo "Copying simulator to edge device. Please provide the vm password when prompted."
-scp -P 2223 -pr ./IotDeviceSimulator/output/* azureUser@$HOST:/home/azureUser/iot-device-simulator
+echo "Copying simulator to edge device."
+VM_FQDN=$(az vm show -d --resource-group $RSG --name $VM_NAME --query "fqdns" -o tsv)
+scp -P 2223 -i ~/.ssh/$SSH_KEY_NAME -pr ./IotDeviceSimulator/output/* azureUser@$VM_FQDN:/home/azureUser/iot-device-simulator
 
-echo "To run the simulator, connect to the vm and run the run-simulator.sh script."
-echo "ssh -p 2223 azureUser@$HOST"
+echo "To run the simulator, run remotely the run-simulator.sh script with the following command:"
+echo "ssh -p 2223 -i ~/.ssh/$SSH_KEY_NAME azureUser@$VM_FQDN \"cd /home/azureUser/iot-device-simulator/;./run-simulator.sh\""

--- a/build-deploy.sh
+++ b/build-deploy.sh
@@ -5,11 +5,7 @@
 ## Ensure that the env.vars.sh script is executable by running: chmod +x env.vars.sh
 ## Run the script by running: ./build-deploy.sh 
 
-export SUFIX=bcdr
-export RSG=iot-$SUFIX
-export HUB=iot-$SUFIX-hub
-export VM_DNS_PREFIX='edgevm-'$SUFIX
-export SSH_KEY_NAME=iot_vm_rsa
+source ${BASH_SOURCE%/*}/variables.sh
 
 source ./IotDeviceSimulator/env.vars.sh
 
@@ -33,4 +29,4 @@ VM_FQDN=$(az vm show -d --resource-group $RSG --name $VM_NAME --query "fqdns" -o
 scp -P 2223 -i ~/.ssh/$SSH_KEY_NAME -pr ./IotDeviceSimulator/output/* azureUser@$VM_FQDN:/home/azureUser/iot-device-simulator
 
 echo "To run the simulator, run remotely the run-simulator.sh script with the following command:"
-echo "ssh -p 2223 -i ~/.ssh/$SSH_KEY_NAME azureUser@$VM_FQDN \"cd /home/azureUser/iot-device-simulator/;./run-simulator.sh\""
+echo 'ssh -p 2223 -i ~/.ssh/$SSH_KEY_NAME azureUser@$VM_FQDN "cd /home/azureUser/iot-device-simulator/;./run-simulator.sh"'

--- a/setup.env.sh
+++ b/setup.env.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 ## YOU CAN RUN THIS SCRIPT FROM THE AZURE CLI OR FROM THE AZURE CLOUD SHELL
@@ -12,7 +11,7 @@ export HUB=iot-$SUFIX-hub
 export ACR=iotacr$SUFIX
 export VNET_WE=iot-$SUFIX-vnet-we
 export VNET_NE=iot-$SUFIX-vnet-ne
-export VM_NAME='edgevm-'$SUFIX
+export VM_DNS_PREFIX='edgevm-'$SUFIX
 
 echo "Preparing testing environment for BC/DR demo."
 echo "SUFIX=$SUFIX"
@@ -27,19 +26,29 @@ echo "Creating resource group $RSG"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 ## CREATE RESOURCE GRUOP
 az group create --name $RSG --location westeurope
-az group create --name $RSG_NE --location westeurope
+az group create --name $RSG_NE --location northeurope
 
 echo "Creating IoT Hub $HUB"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 ## PROVISION IOT HUB
-az iot hub create --resource-group $RSG --name $HUB --sku S1 --partition-count 4
-
+if [ -n "$(az iot hub list --resource-group $RSG --query "[?name=='$HUB'].id" -o tsv)" ]; then
+   echo "$HUB exists"
+else
+   az iot hub create --resource-group $RSG --name $HUB --sku S1 --partition-count 4
+fi
 echo "Creating IoT Edge Device 'edge101' and IoT Device 'thermostat1'"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 ## REGISTER DEVICES
-az iot hub device-identity create --device-id edge101 --edge-enabled --hub-name $HUB --resource-group $RSG
-az iot hub device-identity create --device-id thermostat1 --hub-name $HUB --resource-group $RSG
-
+if [ -n "$(az iot hub device-identity list --hub-name $HUB --resource-group $RSG --query "[?deviceId=='edge101'].deviceId" -o tsv)" ]; then
+   echo "edge101 exists"
+else
+   az iot hub device-identity create --device-id edge101 --edge-enabled --hub-name $HUB --resource-group $RSG
+fi
+if [ -n "$(az iot hub device-identity list --hub-name $HUB --resource-group $RSG --query "[?deviceId=='thermostat1'].deviceId" -o tsv)" ]; then
+   echo "thermostat1 exists"
+else
+  az iot hub device-identity create --device-id thermostat1 --hub-name $HUB --resource-group $RSG
+fi
 ## SHOW DEVICES CONN STRINGS
 az iot hub device-identity connection-string show --device-id edge101 --hub-name $HUB --resource-group $RSG
 az iot hub device-identity connection-string show --device-id thermostat1 --hub-name $HUB --resource-group $RSG
@@ -50,16 +59,31 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 az deployment group create \
 --resource-group $RSG \
 --template-uri "https://raw.githubusercontent.com/Azure/iotedge-vm-deploy/1.4/edgeDeploy.json" \
---parameters dnsLabelPrefix=$VM_NAME \
+--parameters dnsLabelPrefix=$VM_DNS_PREFIX \
 --parameters adminUsername='azureUser' \
 --parameters deviceConnectionString=$(az iot hub device-identity connection-string show --device-id edge101 --hub-name $HUB --resource-group $RSG -o tsv) \
 --parameters authenticationType='password' \
 --parameters adminPasswordOrKey="vmPass#word"
 
+echo "Wait for VM to boot"
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+VM_NAME=$(az vm list -g $RSG -d --query "[?starts_with(fqdns,'$VM_DNS_PREFIX')].name" -o tsv)
+while true
+do
+    powerState=$(az vm show --resource-group $RSG --name $VM_NAME -d --query "powerState" -o tsv)
+    if [ "$powerState" != "VM running" ]
+    then
+        echo "VM is booting. Sleeping for a bit..."
+        sleep 10
+    else
+        echo "VM is running. Continuing with script..."
+        break
+    fi
+done
+
 echo "Configuring VM SSH on port 2223"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 ## CONFIGURE VM SSH ON PORT 2223
-VM_NAME=$(az vm list -g $RSG --query "[].name" -o tsv)
 az vm run-command invoke -g $RSG  -n $VM_NAME --command-id RunShellScript --scripts "sudo sed -i -e 's/#Port 22/Port 2223/' /etc/ssh/sshd_config"
 az vm run-command invoke -g $RSG  -n $VM_NAME --command-id RunShellScript --scripts "sudo cat /etc/ssh/sshd_config"
 az vm run-command invoke -g $RSG  -n $VM_NAME --command-id RunShellScript --scripts "sudo systemctl restart ssh"
@@ -74,15 +98,16 @@ az network nsg rule create --resource-group $RSG --nsg-name $NSG_NAME --name Blo
 echo "Configuring VNETs"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 ## SETUP VNETS
-VNET_VM=$(az network vnet list -g $RSG --query "[].name" -o tsv)
+VNET_VM=$(az network vnet list -g $RSG --query "[?starts_with(name,'vnet-')].name" -o tsv)
 az network vnet create --resource-group $RSG --name $VNET_WE --address-prefix 10.1.0.0/16 --subnet-name default --subnet-prefix 10.1.0.0/24 --location westeurope
 az network vnet create --resource-group $RSG_NE --name $VNET_NE --address-prefix 10.2.0.0/16 --subnet-name default --subnet-prefix 10.2.0.0/24 --location northeurope
  
 echo "Configuring VNET peering"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+VNET_WE_ID=$(az network vnet show -g $RSG -n $VNET_WE --query id -o tsv)
 VNET_NE_ID=$(az network vnet show -g $RSG_NE -n $VNET_NE --query id -o tsv)
-az network vnet peering create --name vnet-onprem-to-vnet-we --resource-group $RSG --vnet-name $VNET_VM --remote-vnet $VNET_WE --allow-vnet-access
-az network vnet peering create --name vnet-onprem-to-vnet-ne --resource-group $RSG --vnet-name $VNET_VM --remote-vnet $VNET_NE  --remote-vnet $VNET_NE_ID --allow-vnet-access
+az network vnet peering create --name vnet-onprem-to-vnet-we --resource-group $RSG --vnet-name $VNET_VM --remote-vnet $VNET_WE_ID --allow-vnet-access
+az network vnet peering create --name vnet-onprem-to-vnet-ne --resource-group $RSG --vnet-name $VNET_VM --remote-vnet $VNET_NE_ID --allow-vnet-access
 
 
 echo "Configuring Storage Account"
@@ -91,13 +116,13 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 az storage account create --name iotstg$SUFIX --resource-group $RSG --location westeurope --sku Standard_LRS --kind StorageV2
 
 az acr create --resource-group $RSG --name $ACR --sku Premium --admin-enabled true
-az acr import --resource-group $RSG --name $ACR --source mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:latest --image azureiotedge-simulated-temperature-sensor:latest
+az acr import --resource-group $RSG --name $ACR --source mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:latest --image azureiotedge-simulated-temperature-sensor:latest --force
 
 ## MANUAL ACTIONS
 # - ENABLE PRIVATE LINK FOR WE
 # Ref: https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-public-network-access
-
-echo "To connect to the VM run: ssh -p 2223 azureUser@$VM_NAME.westeurope.cloudapp.azure.com password: vmPass#word"
+VM_FQDN=$(az vm show -d --resource-group $RSG --name $VM_NAME --query "fqdns" -o tsv)
+echo "To connect to the VM run: ssh -p 2223 azureUser@$VM_FQDN password: vmPass#word"
 echo "You will need to MANUALLY create the private endpoints in the WE VNET (and NE when required) for the IoT Hub"
 echo "ALSO you need to create the PE for the ACR"
 echo "You will need to configure the IoT Edge device (edge101) to deploy the TemperatureSensorModule from the market place"

--- a/setup.env.sh
+++ b/setup.env.sh
@@ -7,7 +7,7 @@
 source ${BASH_SOURCE%/*}/variables.sh
 
 echo "Preparing testing environment for BC/DR demo."
-echo "SUFIX=$SUFIX"
+echo "SUFFIX=$SUFFIX"
 echo "RSG=$RSG"
 echo "RSG_NE=$RSG_NE"
 echo "HUB=$HUB"
@@ -113,7 +113,7 @@ az network vnet peering create --name vnet-onprem-to-vnet-ne --resource-group $R
 echo "Configuring Storage Account"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 ## SETUP STORAGE ACCOUNT
-az storage account create --name iotstg$SUFIX --resource-group $RSG --location westeurope --sku Standard_LRS --kind StorageV2
+az storage account create --name iotstg$SUFFIX --resource-group $RSG --location westeurope --sku Standard_LRS --kind StorageV2
 
 az acr create --resource-group $RSG --name $ACR --sku Premium --admin-enabled true
 az acr import --resource-group $RSG --name $ACR --source mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:latest --image azureiotedge-simulated-temperature-sensor:latest --force

--- a/setup.env.sh
+++ b/setup.env.sh
@@ -4,16 +4,7 @@
 ## ENSURE YOU MAKE IT AN EXECUTABLE SCRIPT BY RUNNING: chmod +x setup.env.sh
 ## RUN THE SCRIPT BY RUNNING: . setup.env.sh or source setup.env.sh (if you want the env vars available in the current shell)
 
-export SUFIX=bcdr
-export RSG=iot-$SUFIX
-export RSG_NE=iot-$SUFIX-ne
-export HUB=iot-$SUFIX-hub
-export ACR=iotacr$SUFIX
-export VNET_WE=iot-$SUFIX-vnet-we
-export VNET_NE=iot-$SUFIX-vnet-ne
-export VM_DNS_PREFIX='edgevm-'$SUFIX
-
-export SSH_KEY_NAME=iot_vm_rsa
+source ${BASH_SOURCE%/*}/variables.sh
 
 echo "Preparing testing environment for BC/DR demo."
 echo "SUFIX=$SUFIX"

--- a/variables.sh
+++ b/variables.sh
@@ -1,10 +1,10 @@
-export SUFIX=bcdr
-export RSG=iot-$SUFIX
-export RSG_NE=iot-$SUFIX-ne
-export HUB=iot-$SUFIX-hub
-export ACR=iotacr$SUFIX
-export VNET_WE=iot-$SUFIX-vnet-we
-export VNET_NE=iot-$SUFIX-vnet-ne
-export VM_DNS_PREFIX='edgevm-'$SUFIX
+export SUFFIX=bcdr
+export RSG=iot-$SUFFIX
+export RSG_NE=iot-$SUFFIX-ne
+export HUB=iot-$SUFFIX-hub
+export ACR=iotacr$SUFFIX
+export VNET_WE=iot-$SUFFIX-vnet-we
+export VNET_NE=iot-$SUFFIX-vnet-ne
+export VM_DNS_PREFIX='edgevm-'$SUFFIX
 
 export SSH_KEY_NAME=iot_vm_rsa

--- a/variables.sh
+++ b/variables.sh
@@ -1,0 +1,10 @@
+export SUFIX=bcdr
+export RSG=iot-$SUFIX
+export RSG_NE=iot-$SUFIX-ne
+export HUB=iot-$SUFIX-hub
+export ACR=iotacr$SUFIX
+export VNET_WE=iot-$SUFIX-vnet-we
+export VNET_NE=iot-$SUFIX-vnet-ne
+export VM_DNS_PREFIX='edgevm-'$SUFIX
+
+export SSH_KEY_NAME=iot_vm_rsa


### PR DESCRIPTION
Fancy, completely not necessary, suggestions:
- Allow rerun without warnings or errors:
  - Locate VM's vnet using `starts_with(name,'vnet-')`.
  - Check if the VM is running before configuring the ssh port.
  - Check if device identities already registered in IoT Hub.
  - Force import the `latest` tag from `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor`.
- Use generated SSH key instead of password. Key generated in `~/.ssh/iot_vm_rsa` with pub key in `~/.ssh/iot_vm_rsa.pub` and you can change the name in the `variables.sh` file.
- Centralize variables in `variables.sh` to make it easy to change SUFFIX.
- Suggest to user to remote execute simulator instead of having to login to VM.
- NE resource group created in `northeurope`.
- Locate VM's name using the `VM_DNS_PREFIX` variable.
- Look up FQDN of the VM to avoid hardcoding the region.
- Lint `Readme.md` using [MS Learn Authoring pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack).